### PR TITLE
fix(py): fix SSL for python > 3.8

### DIFF
--- a/hisensetv/__main__.py
+++ b/hisensetv/__main__.py
@@ -117,6 +117,8 @@ def main():
     elif args.certfile is not None and args.keyfile is not None:
         ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         ssl_context.load_cert_chain(certfile=args.certfile, keyfile=args.keyfile)
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
         logger.info("SSL context created with cert file (" + args.certfile + ") and private key (" + args.keyfile + ")")
     else:
         ssl_context = ssl._create_unverified_context()

--- a/hisensetv/__main__.py
+++ b/hisensetv/__main__.py
@@ -115,7 +115,7 @@ def main():
         logger.info("No SSL context specified.")
         ssl_context = None
     elif args.certfile is not None and args.keyfile is not None:
-        ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         ssl_context.load_cert_chain(certfile=args.certfile, keyfile=args.keyfile)
         logger.info("SSL context created with cert file (" + args.certfile + ") and private key (" + args.keyfile + ")")
     else:


### PR DESCRIPTION
Fix error "ssl.SSLError: Cannot create a client socket with a PROTOCOL_TLS_SERVER context " display on Python3.10